### PR TITLE
1.8 cbtimer resolution

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -236,6 +236,7 @@ struct flb_config {
     void *sched;
     unsigned int sched_cap;
     unsigned int sched_base;
+    uint64_t cb_timer_event_timestamp;
 
     struct flb_task_map tasks_map[2048];
 

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -33,6 +33,7 @@
 #endif
 
 #include <stdlib.h>
+#include <unistd.h>
 
 /*
  * The following memory handling wrappers, aims to simplify the way to use
@@ -54,6 +55,8 @@
 static inline ALLOCSZ_ATTR(1)
 void *flb_malloc(const size_t size) {
     void *aux;
+
+    usleep(2000);
 
     if (size == 0) {
         return NULL;

--- a/include/fluent-bit/flb_upstream_conn.h
+++ b/include/fluent-bit/flb_upstream_conn.h
@@ -98,7 +98,7 @@ struct flb_upstream_conn {
 int flb_upstream_conn_recycle(struct flb_upstream_conn *conn, int val);
 struct flb_upstream_conn *flb_upstream_conn_get(struct flb_upstream *u);
 int flb_upstream_conn_release(struct flb_upstream_conn *u_conn);
-int flb_upstream_conn_timeouts(struct mk_list *list);
+int flb_upstream_conn_timeouts(uint64_t cb_schedule_timestamp, struct mk_list *list);
 int flb_upstream_conn_pending_destroy(struct flb_upstream *u);
 int flb_upstream_conn_pending_destroy_list(struct mk_list *list);
 int flb_upstream_conn_active_destroy_list(struct mk_list *list);

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -55,7 +55,7 @@ static void cb_thread_sched_timer(struct flb_config *ctx, void *data)
 
     /* Upstream connections timeouts handling */
     ins = (struct flb_output_instance *) data;
-    flb_upstream_conn_timeouts(&ins->upstreams);
+    flb_upstream_conn_timeouts(SIZE_MAX, &ins->upstreams);
 }
 
 static inline int handle_output_event(struct flb_config *config,


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
